### PR TITLE
Fix `Mesh.circle2D()` to produce expected mesh

### DIFF
--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -91,16 +91,24 @@ export class Mesh {
 
   /**
    * @param {number} radius
-   * @param {number} _resolution
+   * @param {number} resolution
    * @returns {Mesh}
    */
-  static circle2D(radius, _resolution = 16) {
+  static circle2D(radius, resolution = 16) {
     const geometry = new Mesh()
-    const positions = new Float32Array([radius, radius])
+    const positions = [0,0]
 
+    const spacing = Math.PI * 2 / resolution
 
-    // TODO - fix up resolution
-    geometry.setAttribute('position2d', new Attribute(positions))
+    for (let i = 0; i <= resolution; i++) {
+      const position = Vector2.fromAngle(spacing * i)
+      Vector2.multiplyScalar(position,radius,position)
+
+      positions.push(position.x,position.y)
+    }
+    
+    geometry
+      .setAttribute('position2d', new Attribute(new Float32Array(positions)))
 
     return geometry
   }


### PR DESCRIPTION
## Objective
 - Fix #28

## Solution
Mesh generated is now a 2d circle mesh.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.