### PR TITLE
Change `AssetBasePath` to `AssetBasePath<T>`

### DIFF
--- a/src/asset/resources/assetbasepath.js
+++ b/src/asset/resources/assetbasepath.js
@@ -1,4 +1,13 @@
+/**
+ * @template T
+ */
 export class AssetBasePath {
+
+  /**
+   * @private
+   * @type {T | undefined}
+   */
+  marker
 
   /**
    * @type {string}


### PR DESCRIPTION
## Objective
 - Makes `AssetBasePath` generic for all asset types.
  This means that each asset type will have its own unique base path instead of a global base path.
 - Updates systems using `AssetBasePath`.

## Solution
N/A

## Showcase
N/A

## Migration guide
If you were using the global asset base path, replace it with the base path of the required type of asset

Before:
```typescript
// This is shared between asset types.
const basepath = new AssetBasePath()
```
After:
```typescript
// This are the asset types
class Image {}
class Audio {}

// This is the base path for images.
const basepath = new AssetBasePath<Image>()

// This is the base path for the audio.
const basepath = new AssetBasePath<Audio>()
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.