### PR TITLE
Add `Defaultable<T>`

### DIFF
--- a/src/utils/typedef/defaultable.js
+++ b/src/utils/typedef/defaultable.js
@@ -1,0 +1,6 @@
+/**
+ * @template T
+ * @typedef Defaultable
+ * @property {()=>T} default
+ */
+export default {}

--- a/src/utils/typedef/index.js
+++ b/src/utils/typedef/index.js
@@ -1,1 +1,2 @@
 export * from './typearray.js'
+export * from './defaultable.js'


### PR DESCRIPTION
## Objective
Adds a  new interface which enforces a class to have a static method `default()` which is used to create a default object of the class.

Currently cannot be directly enforced on a class as explained in [this issue](https://github.com/microsoft/TypeScript/issues/33892).Will be enforced in functions/methods which accept classes.

This was inspired by the rust language `Default` trait.

## Solution
N/A

## Showcase
Javascript:
```javascript
class Something {
  static default(){
    return new Something()
  }
}

/**
  * @template T
  * @param {Defaultable<T>} that
  * @returns T
  */
function createSomething(that){
  const a = Something.default()
  return a
}

const something = createSomething(Something)
```
Typescript:
```typescript
class Something {
  // this is the method required by `Defaultable<T>`
  static default(){
    return new Something()
  }
}

function createSomething<T>(that:Defaultable<T>):T{
  const a = Something.default()
  return a
}

const something = createSomething(Something)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.